### PR TITLE
Update links grape in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,8 +8,8 @@ The http://www.ruby-grape.org site is work of [many contributors](https://github
 Fork the [project on Github](https://github.com/ruby-grape/ruby-grape.github.io) and check out your copy.
 
 ```
-git clone https://github.com/contributor/grape.git
-cd grape
+git clone https://github.com/contributor/ruby-grape.github.io.git
+cd ruby-grape.github.io
 git remote add upstream https://github.com/ruby-grape/ruby-grape.github.io.git
 ```
 


### PR DESCRIPTION
There were a couple of references to the grape proejct, this makes the following change: `grape` -> `ruby-grape.github.io`
