### PR TITLE
Added a mention of Screenhero, long-time users of Grape.

### DIFF
--- a/users/index.md
+++ b/users/index.md
@@ -12,6 +12,7 @@ There're thousands of companies using Grape, this page was started recently. The
 * [Artsy.net](https://www.artsy.net) has a [public API](https://developers.artsy.net) built with Grape.
 * [Devex.com](https://www.devex.com) is a media platform for the global development community. We use Grape internally and expose some endpoints to partners.
 * [Ramen.is](https://ramen.is) makes it easy for SaaS companies to ask their customers simple, highly-targeted, in-app questions that they actually answer. Their backend integration with [Segment.com](https://segment.com/docs/integrations/ramen) is built on Grape.
+* [Screenhero](https://screenhero.com), now sadly defunct, offers screensharing with real-time interactivity. Screenhero made extensive use of Grape for its private and public APIs (*e.g.* as used by Slack's integration).
 
 ### Contribute
 


### PR DESCRIPTION
At @dblock's suggestion, I'm adding a line that mentions Screenhero's APIs, which were built on Grape.
