### PR TITLE
Grape is not a `micro` framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![](images/grape.png)
 
-Grape is an opinionated micro-framework for creating REST-like APIs in Ruby.
+Grape is an opinionated framework for creating REST-like APIs in Ruby.
 This is the Jekyll source for the site at http://www.ruby-grape.org.
 
 Please contribute to this site, see [CONTRIBUTING](CONTRIBUTING.md).

--- a/_config.yml
+++ b/_config.yml
@@ -1,5 +1,5 @@
 title:
-  long: Ruby Grape | An opinionated micro-framework for creating REST-like APIs in Ruby.
+  long: Ruby Grape | An opinionated framework for creating REST-like APIs in Ruby.
   short: Ruby Grape
 locale: en_US
 sass:
@@ -12,7 +12,7 @@ kramdown:
 owner:
   name: Ruby Grape
   avatar: logo.png
-  info: An opinionated micro-framework for creating REST-like APIs in Ruby.
+  info: An opinionated framework for creating REST-like APIs in Ruby.
   email: ruby-grape@googlegroups.com
   disqus-shortname:
   twitter: grapeframework

--- a/projects/index.md
+++ b/projects/index.md
@@ -7,7 +7,7 @@ comments: false
 
 ### Core
 
-* [grape](https://github.com/ruby-grape/grape): An opinionated micro-framework for creating REST-like APIs in Ruby.
+* [grape](https://github.com/ruby-grape/grape): An opinionated framework for creating REST-like APIs in Ruby.
 * [ruby-grape.github.io](https://github.com/ruby-grape/ruby-grape.github.io): The ruby-grape community site.
 
 ### Entities and Representers


### PR DESCRIPTION
Reference -- https://github.com/ruby-grape/grape/pull/1363#issuecomment-210082663

Pre history -- 

```
Inspired by https://twitter.com/buka_gor/status/689036018708799492

PS. It's really hard to call grape a micro-framework (no matter how hard you try).
```
