### PR TITLE
Update video link for The Grapes of Rapid talk

### DIFF
--- a/resources/index.md
+++ b/resources/index.md
@@ -7,7 +7,7 @@ comments: false
 
 * [Google Group](https://groups.google.com/group/ruby-grape): Get Grape help here.
 * [Anatomy of a Ruby Gem: Grape](https://vimeo.com/98830727): A screencast digging through the internals of Grape.
-* [The Grapes of Rapid](http://confreaks.net/videos/475-rubyconf2010-the-grapes-of-rapid): RubyConf 2010 presentation about Grape and [slides](https://github.com/downloads/ruby-grape/grape/The%20Grapes%20of%20Rapid.pdf).
+* [The Grapes of Rapid](https://www.youtube.com/watch?v=C7beg3OzxC4): RubyConf 2010 presentation about Grape and [slides](https://github.com/downloads/ruby-grape/grape/The%20Grapes%20of%20Rapid.pdf).
 * [API Authentication w/ Devise](http://code.dblock.org/grape-api-authentication-w-devise): A tutorial on how to use Grape with Devise/Warden authentication.
 * [RESTful APIs with Grape](http://www.slideshare.net/dblockdotorg/building-restful-apis-w-grape): NYC.rb presentation about Grape in 2011.
 * [From Zero to API Cache in 10 Minutes](http://www.confreaks.com/videos/986-goruco2012-from-zero-to-api-cache-w-grape-mongodb-in-10-minutes): a 10-minute talk at GoRuCo 2012 about API caching with Grape.


### PR DESCRIPTION
The old URL for The Grapes of Rapid talk video seems to have been taken over by a domain squatter, so I've updated this link to point to the video on YouTube.