### PR TITLE
Update Zero to API Cache conference link

### DIFF
--- a/resources/index.md
+++ b/resources/index.md
@@ -10,6 +10,6 @@ comments: false
 * [The Grapes of Rapid](https://www.youtube.com/watch?v=C7beg3OzxC4): RubyConf 2010 presentation about Grape and [slides](https://github.com/downloads/ruby-grape/grape/The%20Grapes%20of%20Rapid.pdf).
 * [API Authentication w/ Devise](http://code.dblock.org/grape-api-authentication-w-devise): A tutorial on how to use Grape with Devise/Warden authentication.
 * [RESTful APIs with Grape](http://www.slideshare.net/dblockdotorg/building-restful-apis-w-grape): NYC.rb presentation about Grape in 2011.
-* [From Zero to API Cache in 10 Minutes](http://www.confreaks.com/videos/986-goruco2012-from-zero-to-api-cache-w-grape-mongodb-in-10-minutes): a 10-minute talk at GoRuCo 2012 about API caching with Grape.
+* [From Zero to API Cache in 10 Minutes](https://www.youtube.com/watch?v=e9HLflRXMcA): a 10-minute talk at GoRuCo 2012 about API caching with Grape.
 * [OAuth2: Protect Grape API with Doorkeeper](http://blog.yorkxin.org/posts/2013/11/05/oauth2-tutorial-grape-api-doorkeeper-en): a tutorial for protecting a Grape API with OAuth 2 protocol using Doorkeeper and Ruby on Rails with a [working sample](https://github.com/chitsaou/oauth2-api-sample).
 * [API Heaven with Grape and Swagger](http://bitboxer.de/2014/02/09/rails-api/).


### PR DESCRIPTION
This updates the Zero to API Cache conference link as the current link 404s. 