### PR TITLE
Remove link that doesn't resolve

### DIFF
--- a/users/index.md
+++ b/users/index.md
@@ -11,7 +11,6 @@ There're thousands of companies using Grape, this page was started recently. The
 
 * [Artsy.net](https://www.artsy.net) has a [public API](https://developers.artsy.net) built with Grape.
 * [Devex.com](https://www.devex.com) is a media platform for the global development community. We use Grape internally and expose some endpoints to partners.
-* [Ramen.is](https://ramen.is) makes it easy for SaaS companies to ask their customers simple, highly-targeted, in-app questions that they actually answer. Their backend integration with [Segment.com](https://segment.com/docs/integrations/ramen) is built on Grape.
 * [Screenhero](https://screenhero.com), now sadly defunct, offers screensharing with real-time interactivity. Screenhero made extensive use of Grape for its private and public APIs (*e.g.* as used by Slack's integration).
 * [Meeteor](http://www.meeteor.com), Meeteor is a web app that helps you leverage your meetings to
 drive productivity, build a healthy company culture, and achieve greater


### PR DESCRIPTION
ramen.is doesn't appear valid any longer.